### PR TITLE
Changing URL when displaying the clone interface

### DIFF
--- a/js/zerobin.js
+++ b/js/zerobin.js
@@ -318,6 +318,10 @@ function stateExistingPaste() {
  */
 function clonePaste() {
     stateNewPaste();
+    
+    //Erase the id and the key in url
+    history.replaceState(document.title, document.title, scriptLocation());
+    
     showStatus('');
     $('textarea#message').text($('div#cleartext').text());
 }


### PR DESCRIPTION
This is a little modification of the JS that change the URL when the user click on the clone link. I made this to don't keep the id and the aes key in the url when clonning.
