### PR TITLE
Add openshift support

### DIFF
--- a/.openshift/action_hooks/build
+++ b/.openshift/action_hooks/build
@@ -1,0 +1,5 @@
+#!/bin/bash
+# This is a simple build script and will be executed on your CI system if
+# available.  Otherwise it will execute while your application is stopped
+# before the deploy step.  This script gets executed directly, so it
+# could be python, php, ruby, etc.

--- a/.openshift/action_hooks/deploy
+++ b/.openshift/action_hooks/deploy
@@ -1,0 +1,14 @@
+#!/bin/bash
+# This deploy hook gets executed after dependencies are resolved and the
+# build hook has been run but before the application has been started back
+# up again.  This script gets executed directly, so it could be python, php,
+# ruby, etc.
+
+mkdir -p $OPENSHIFT_REPO_DIR/php
+
+for i in index.php tpl css img js; do
+    ln -s $OPENSHIFT_REPO_DIR/$i $OPENSHIFT_REPO_DIR/php/$i
+done
+
+# neede so paste do not disappear
+ln -s $OPENSHIFT_DATA_DIR/ $OPENSHIFT_REPO_DIR/php/data

--- a/.openshift/action_hooks/post_deploy
+++ b/.openshift/action_hooks/post_deploy
@@ -1,0 +1,4 @@
+#!/bin/bash
+# This is a simple post deploy hook executed after your application
+# is deployed and started.  This script gets executed directly, so
+# it could be python, php, ruby, etc.

--- a/.openshift/action_hooks/post_start_php-5.3
+++ b/.openshift/action_hooks/post_start_php-5.3
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# The pre_start_cartridge and pre_stop_cartridge hooks are *SOURCED*
+# immediately before (re)starting or stopping the specified cartridge.
+# They are able to make any desired environment variable changes as
+# well as other adjustments to the application environment.
+
+# The post_start_cartridge and post_stop_cartridge hooks are executed
+# immediately after (re)starting or stopping the specified cartridge.
+
+# Exercise caution when adding commands to these hooks.  They can
+# prevent your application from stopping cleanly or starting at all.
+# Application start and stop is subject to different timeouts
+# throughout the system.

--- a/.openshift/action_hooks/post_stop_php-5.3
+++ b/.openshift/action_hooks/post_stop_php-5.3
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# The pre_start_cartridge and pre_stop_cartridge hooks are *SOURCED*
+# immediately before (re)starting or stopping the specified cartridge.
+# They are able to make any desired environment variable changes as
+# well as other adjustments to the application environment.
+
+# The post_start_cartridge and post_stop_cartridge hooks are executed
+# immediately after (re)starting or stopping the specified cartridge.
+
+# Exercise caution when adding commands to these hooks.  They can
+# prevent your application from stopping cleanly or starting at all.
+# Application start and stop is subject to different timeouts
+# throughout the system.

--- a/.openshift/action_hooks/pre_build
+++ b/.openshift/action_hooks/pre_build
@@ -1,0 +1,5 @@
+#!/bin/bash
+# This is a simple script and will be executed on your CI system if
+# available.  Otherwise it will execute while your application is stopped
+# before the build step.  This script gets executed directly, so it
+# could be python, php, ruby, etc.

--- a/.openshift/action_hooks/pre_start_php-5.3
+++ b/.openshift/action_hooks/pre_start_php-5.3
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# The pre_start_cartridge and pre_stop_cartridge hooks are *SOURCED*
+# immediately before (re)starting or stopping the specified cartridge.
+# They are able to make any desired environment variable changes as
+# well as other adjustments to the application environment.
+
+# The post_start_cartridge and post_stop_cartridge hooks are executed
+# immediately after (re)starting or stopping the specified cartridge.
+
+# Exercise caution when adding commands to these hooks.  They can
+# prevent your application from stopping cleanly or starting at all.
+# Application start and stop is subject to different timeouts
+# throughout the system.

--- a/.openshift/action_hooks/pre_stop_php-5.3
+++ b/.openshift/action_hooks/pre_stop_php-5.3
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# The pre_start_cartridge and pre_stop_cartridge hooks are *SOURCED*
+# immediately before (re)starting or stopping the specified cartridge.
+# They are able to make any desired environment variable changes as
+# well as other adjustments to the application environment.
+
+# The post_start_cartridge and post_stop_cartridge hooks are executed
+# immediately after (re)starting or stopping the specified cartridge.
+
+# Exercise caution when adding commands to these hooks.  They can
+# prevent your application from stopping cleanly or starting at all.
+# Application start and stop is subject to different timeouts
+# throughout the system.

--- a/.openshift/cron/README.cron
+++ b/.openshift/cron/README.cron
@@ -1,0 +1,22 @@
+Run scripts or jobs on a periodic basis
+=======================================
+Any scripts or jobs added to the minutely, hourly, daily, weekly or monthly
+directories will be run on a scheduled basis (frequency is as indicated by the
+name of the directory) using run-parts.
+
+run-parts ignores any files that are hidden or dotfiles (.*) or backup
+files (*~ or *,)  or named *.{rpmsave,rpmorig,rpmnew,swp,cfsaved}
+
+The presence of two specially named files jobs.deny and jobs.allow controls
+how run-parts executes your scripts/jobs.
+   jobs.deny  ===> Prevents specific scripts or jobs from being executed.
+   jobs.allow ===> Only execute the named scripts or jobs (all other/non-named
+                   scripts that exist in this directory are ignored).
+
+The principles of jobs.deny and jobs.allow are the same as those of cron.deny
+and cron.allow and are described in detail at:
+   http://docs.redhat.com/docs/en-US/Red_Hat_Enterprise_Linux/6/html/Deployment_Guide/ch-Automating_System_Tasks.html#s2-autotasks-cron-access
+
+See: man crontab or above link for more details and see the the weekly/
+     directory for an example.
+

--- a/.openshift/cron/weekly/README
+++ b/.openshift/cron/weekly/README
@@ -1,0 +1,16 @@
+Run scripts or jobs on a weekly basis
+=====================================
+Any scripts or jobs added to this directory will be run on a scheduled basis
+(weekly) using run-parts.
+
+run-parts ignores any files that are hidden or dotfiles (.*) or backup
+files (*~ or *,)  or named *.{rpmsave,rpmorig,rpmnew,swp,cfsaved} and handles
+the files named jobs.deny and jobs.allow specially.
+
+In this specific example, the chronograph script is the only script or job file
+executed on a weekly basis (due to white-listing it in jobs.allow). And the
+README and chrono.dat file are ignored either as a result of being black-listed
+in jobs.deny or because they are NOT white-listed in the jobs.allow file.
+
+For more details, please see ../README.cron file.
+

--- a/.openshift/cron/weekly/chrono.dat
+++ b/.openshift/cron/weekly/chrono.dat
@@ -1,0 +1,1 @@
+Time And Relative D...n In Execution (Open)Shift!

--- a/.openshift/cron/weekly/chronograph
+++ b/.openshift/cron/weekly/chronograph
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "`date`: `cat $(dirname \"$0\")/chrono.dat`"

--- a/.openshift/cron/weekly/jobs.allow
+++ b/.openshift/cron/weekly/jobs.allow
@@ -1,0 +1,12 @@
+#
+#  Script or job files listed in here (one entry per line) will be
+#  executed on a weekly-basis.
+#
+#  Example: The chronograph script will be executed weekly but the README
+#           and chrono.dat files in this directory will be ignored.
+#
+#           The README file is actually ignored due to the entry in the
+#           jobs.deny which is checked before jobs.allow (this file).
+#
+chronograph
+

--- a/.openshift/cron/weekly/jobs.deny
+++ b/.openshift/cron/weekly/jobs.deny
@@ -1,0 +1,7 @@
+#
+#  Any script or job files listed in here (one entry per line) will NOT be
+#  executed (read as ignored by run-parts).
+#
+
+README
+

--- a/.openshift/markers/README
+++ b/.openshift/markers/README
@@ -1,0 +1,11 @@
+Markers
+===========
+
+Adding marker files to this directory will have the following effects:
+
+force_clean_build - Will remove all previous php pears and start installing
+    required pears from scratch
+
+hot_deploy - Will prevent the apache process from being restarted during
+    build/deployment
+

--- a/README.openshift.md
+++ b/README.openshift.md
@@ -1,0 +1,30 @@
+ZeroBin on OpenShift
+====================
+
+This git repository helps you get up and running quickly w/ a ZeroBin installation
+on OpenShift.
+
+Running ZeroBin on OpenShift
+----------------------------
+
+Create an account at http://openshift.redhat.com/
+
+Create a php-5.3 application (you can call your application whatever you want)
+
+    rhc app create -a zerobin -t php-5.3
+
+Add this upstream zerobin repo
+
+    cd zerobin
+    git remote add upstream -m master git://github.com/mscherer/zerobin.git
+    git pull -s recursive -X theirs upstream master
+    # note that the git pull above can be used later to pull updates to ZeroBin
+
+Then push the repo upstream
+
+    git push
+
+That's it, you can now checkout your application at :
+
+    http://zerobin-$yournamespace.rhcloud.com
+


### PR DESCRIPTION
with just the directory ( in fact, just .openshift/action_hooks/deploy ),
zerobin should be usable out of the box on openshift platform, after following
the instruction in README.openshift.md. In short, deploy will just
setup symlink so apache can run and find the needed file.

The paste dump are stored in a directory that should survive reboot
of the instance, but this was not fully tested.

The rest of the files are just placeholder and could be removed.
