### PR TITLE
Ignore .htaccess and .htpasswd for safety

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 # Ignore data/ and tmp/
 data/
 tmp/
+# Ignore for safety
+.htaccess
+.htpasswd


### PR DESCRIPTION
Most of users use .htaccess on ZeroBin to make their specific settings, e.g. additional security level. Until here will be custom .htaccess - will be gentle to add them to .gitignore so even forks will not publish them accidentally.
