### PR TITLE
File lock for write on /data/traffic_limiter.php

### DIFF
--- a/index.php
+++ b/index.php
@@ -35,7 +35,7 @@ function trafic_limiter_canPass($ip)
         // FIXME: purge file of expired IPs to keep it small
     }
     $tl[$ip]=time();
-    file_put_contents($tfilename, "<?php\n\$GLOBALS['trafic_limiter']=".var_export($tl,true).";\n?>");
+    file_put_contents($tfilename, "<?php\n\$GLOBALS['trafic_limiter']=".var_export($tl,true).";\n?>", LOCK_EX);
     return true;
 }
 


### PR DESCRIPTION
Adding an LOCK_EX for write on file /data/traffic_limiter.php for preventing that one instance is reading data while a write by another instance is not finished.
